### PR TITLE
FIX: REMOVE_NEO4J: [Search] Relax "required" requirements for "primary"/"secondary" in SetDesignTaggingsObject [CON-1687]

### DIFF
--- a/docs/SetDesignTaggingsObject.md
+++ b/docs/SetDesignTaggingsObject.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **design_id** | **Integer** | design id | 
 **discoverable** | **BOOLEAN** | true if the design is discoverable | 
 **discoverable_before** | **BOOLEAN** | true if the design was already discoverable | 
-**primary** | **String** | primary tag name | 
-**secondary** | **Array&lt;String&gt;** | secondary tag names | 
+**primary** | **String** | primary tag name | [optional] 
+**secondary** | **Array&lt;String&gt;** | secondary tag names | [optional] 
 
 

--- a/lib/swagger_client/models/set_design_taggings_object.rb
+++ b/lib/swagger_client/models/set_design_taggings_object.rb
@@ -98,14 +98,6 @@ module SwaggerClient
         invalid_properties.push('invalid value for "discoverable_before", discoverable_before cannot be nil.')
       end
 
-      if @primary.nil?
-        invalid_properties.push('invalid value for "primary", primary cannot be nil.')
-      end
-
-      if @secondary.nil?
-        invalid_properties.push('invalid value for "secondary", secondary cannot be nil.')
-      end
-
       invalid_properties
     end
 
@@ -115,8 +107,6 @@ module SwaggerClient
       return false if @design_id.nil?
       return false if @discoverable.nil?
       return false if @discoverable_before.nil?
-      return false if @primary.nil?
-      return false if @secondary.nil?
       true
     end
 


### PR DESCRIPTION
### Context

Relax the "required" requirements for "primary"/"secondary" in SetDesignTaggingsObject in the new Search API to mimic what the (non-validating) Neo4j design model that the new Search API is meant to replace.

See also [CON-1687](https://teepublic.atlassian.net/browse/CON-1687).

### Proposed Changes

- update files affected by re-running `java --add-opens=java.base/java.util=ALL-UNNAMED -jar ./lib/swagger-codegen-cli-2.4.19.jar generate -i search_swagger_2_0.yaml -l ruby -o ../teepublic-search-client/` from the `teepublic-search` repo;
- manually update `SwaggerClient.VERSION` to 1.0.38 (previously set to 1.0.38, reset to 1.0.0 by swagger-codegen above before manual update). 

### Automated Tests and QA
- manually tested that Marketplace can still successfully query Search and post changes to Search

[CON-1687]: https://teepublic.atlassian.net/browse/CON-1687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ